### PR TITLE
fix: job pricing with BigNumber

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export default class DeepSquareClient {
               : 4,
             batchLocationHash: hash.submit,
           },
-          BigNumber.from(1e3).mul('1000000000000000000'),
+          parseUnits((1e3).toString(), "ether"),
           formatBytes32String(jobName),
           true
         )

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export default class DeepSquareClient {
               : 4,
             batchLocationHash: hash.submit,
           },
-          parseUnits(1.6.toString(), "ether"),
+          BigNumber.from(1e3).mul('1000000000000000000'),
           formatBytes32String(jobName),
           true
         )


### PR DESCRIPTION
The way the price is calculated generates a BAL1 revert. 

I use this : `BigNumber.from(1e3).mul('1000000000000000000')` to make it work.