### PR TITLE
fix : factory pattern for GRPC

### DIFF
--- a/src/grpc/client.ts
+++ b/src/grpc/client.ts
@@ -1,12 +1,11 @@
 import { GrpcTransport } from "@protobuf-ts/grpc-transport";
-import {LoggerAPIClient} from "./generated/logger/v1alpha1/log.client";
+import { LoggerAPIClient } from "./generated/logger/v1alpha1/log.client";
 import { ChannelCredentials } from "@grpc/grpc-js";
 
-const transport = new GrpcTransport({
-        host: "grid-logger.deepsquare.run:443",
-        channelCredentials: ChannelCredentials.createSsl(),
-});
-
-const loggerClient = new LoggerAPIClient(transport);
-
-export default loggerClient;
+export function createLoggerClient(): LoggerAPIClient {
+        const transport = new GrpcTransport({
+                host: "grid-logger.deepsquare.run:443",
+                channelCredentials: ChannelCredentials.createSsl(),
+        });
+        return new LoggerAPIClient(transport);
+}

--- a/src/grpc/service.ts
+++ b/src/grpc/service.ts
@@ -1,13 +1,16 @@
 import { arrayify } from '@ethersproject/bytes';
 import type { JsonRpcProvider } from '@ethersproject/providers';
-import { LoggerAPIClient } from "./generated/logger/v1alpha1/log.client";
 import { ReadResponse } from "./generated/logger/v1alpha1/log";
+import { LoggerAPIClient } from "./generated/logger/v1alpha1/log.client";
 import { Wallet } from '@ethersproject/wallet';
 
 export class GRPCService {
   private abortReadAndWatch: AbortController | null = null;
+  private loggerClient: LoggerAPIClient;
 
-  constructor(private loggerClient: LoggerAPIClient, private provider: JsonRpcProvider, private wallet: Wallet) { }
+  constructor(private loggerClientFactory: () => LoggerAPIClient, private provider: JsonRpcProvider, private wallet: Wallet) {
+    this.loggerClient = loggerClientFactory();
+  }
 
   async readAndWatch(address: string, logName: string): Promise<AsyncIterable<ReadResponse>> {
     this.abortReadAndWatch = new AbortController();


### PR DESCRIPTION
Solves the bug creating weird behavior as soon as more than one grpc connection for log fetching was used. 
We changed the singleton pattern used by a factory pattern. 

Potential improvement, but I don't think we need them now as the library in its current status is not usable. 

The factory pattern itself does not handle disconnections from the client. However, since the LoggerAPIClient instance is created each time the factory function is called, it is possible to handle disconnections by recreating the client instance when necessary.

One approach to handling disconnections is to catch any errors thrown by the gRPC calls and recreate the client instance if an error occurs. For example, you can modify the readAndWatch method in GRPCService to catch any errors and recreate the client instance:

```typescript
async readAndWatch(address: string, logName: string): Promise<AsyncIterable<ReadResponse>> {
  this.abortReadAndWatch = new AbortController();
  const timestamp = Date.now();
  const msg = `read:${address.toLowerCase()}/${logName}/${timestamp}`;
  const signedHash: string = await this.wallet.signMessage(msg);

  try {
    const { responses } = this.loggerClient.read(
      {
        address: address,
        logName: logName,
        timestamp: BigInt(timestamp),
        signedHash: arrayify(signedHash),
      },
      {
        abort: this.abortReadAndWatch.signal,
        timeout: 3_600_000, // 1h
      },
    );
    return responses;
  } catch (error) {
    console.error('gRPC error occurred:', error);
    // Recreate the client instance
    this.loggerClient = this.loggerClientFactory();
    throw error;
  }
}
```

This code catches any errors thrown by the loggerClient.read call and recreates the client instance by calling the factory function. Then it rethrows the error so that the calling code can handle it appropriately.

With this approach, you can handle disconnections by recreating the client instance when necessary.